### PR TITLE
Add TLS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Some things on the backlog:
 - [ ] Add CI (CircleCI or TravisCI)
 - [ ] Add tests
 - [ ] Add code coverage
-- [ ] Add TLS support for gRPC
+- [x] Add TLS support for gRPC
 - [ ] Add message headers support
 - [ ] Add message ACK support (scaffolding is already done)
 - [x] Add method to close connection

--- a/python_liftbridge/base.py
+++ b/python_liftbridge/base.py
@@ -24,15 +24,16 @@ class BaseClient(object):
                 'Creating a secure channel with address: %s' %
                 self.ip_address,
             )
-            self.stub = self._secure_connect(tls_cert)
+            self.channel = self._secure_channel(self.ip_address,tls_cert)
+            self.stub = self._connect()
         else:
             logger.debug(
                 'Creating an insecure channel with address: %s' % self.ip_address,
             )
             self.channel = grpc.insecure_channel(self.ip_address)
-            self.stub = self._insecure_connect()
+            self.stub = self._connect()
 
-    def _insecure_connect(self):
+    def _connect(self):
         try:
             grpc.channel_ready_future(
                 self.channel,
@@ -42,9 +43,12 @@ class BaseClient(object):
         else:
             return python_liftbridge.api_pb2_grpc.APIStub(self.channel)
 
-    def _secure_connect(self, secure_file):
-        # TODO
-        pass
+    def _secure_channel(self, address, secure_file):
+        with open(secure_file) as f:
+            trusted_certs = f.read().encode()
+        credentials = grpc.ssl_channel_credentials(root_certificates=trusted_certs)
+        return grpc.secure_channel(address, credentials)
+        
 
     def close(self):
         logger.debug('Closing channel')

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open('README.md') as f:
 
 setup(
     name='python-liftbridge',
-    version='0.0.5',
+    version='0.0.6',
     description='Python client for Liftbridge.',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
This PR allows the Python client to use certificate-based TLS authentication with the server.

Signed-off-by: dgzlopes <danielgonzalezlopes@gmail.com>