### PR TITLE
Add delete_stream, fix subscription first message behaviour, add timeout to subscribe

### DIFF
--- a/python_liftbridge/__init__.py
+++ b/python_liftbridge/__init__.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import
 from python_liftbridge.errors import ErrChannelClosed  # noqa: F401
 from python_liftbridge.errors import ErrNoSuchStream  # noqa: F401
 from python_liftbridge.errors import ErrStreamExists  # noqa: F401
+from python_liftbridge.errors import ErrDeadlineExceeded  # noqa: F401
 from python_liftbridge.message import Message  # noqa: F401
 from python_liftbridge.python_liftbridge import Lift  # noqa: F401
 from python_liftbridge.stream import Stream  # noqa: F401

--- a/python_liftbridge/errors.py
+++ b/python_liftbridge/errors.py
@@ -21,6 +21,12 @@ class ErrChannelClosed(Exception):
         super().__init__(message)
 
 
+class ErrDeadlineExceeded(Exception):
+    def __init__(self, message=None):
+        message = message or 'Timeout exceeded or Client cancelled'
+        super().__init__(message)
+
+
 def handle_rpc_errors(fnc):
     """Decorator to add more context to RPC errors"""
 
@@ -36,6 +42,8 @@ def handle_rpc_errors(fnc):
                 raise ErrStreamExists from None
             elif e.code() == grpc.StatusCode.CANCELLED:
                 raise ErrChannelClosed from None
+            elif e.code() == grpc.StatusCode.DEADLINE_EXCEEDED:
+                raise ErrDeadlineExceeded from None
             else:
                 print('Failed with {1}: {2}'.format(e.code(), e.details()))
     return wrapper
@@ -56,6 +64,8 @@ def handle_rpc_errors_in_generator(fnc):
                 raise ErrStreamExists from None
             elif e.code() == grpc.StatusCode.CANCELLED:
                 raise ErrChannelClosed from None
+            elif e.code() == grpc.StatusCode.DEADLINE_EXCEEDED:
+                raise ErrDeadlineExceeded from None
             else:
                 print('Failed with {1}: {2}'.format(e.code(), e.details()))
     return wrapper

--- a/python_liftbridge/python_liftbridge.py
+++ b/python_liftbridge/python_liftbridge.py
@@ -3,8 +3,7 @@ from logging import NullHandler
 
 import python_liftbridge.api_pb2
 from python_liftbridge.base import BaseClient
-from python_liftbridge.errors import handle_rpc_errors
-from python_liftbridge.errors import handle_rpc_errors_in_generator
+from python_liftbridge.errors import handle_rpc_errors, handle_rpc_errors_in_generator, ErrDeadlineExceeded, ErrChannelClosed
 from python_liftbridge.message import Message  # noqa: F401
 from python_liftbridge.stream import Stream  # noqa: F401
 
@@ -18,7 +17,7 @@ class Lift(BaseClient):
         # TODO
         return self._fetch_metadata(self._fetch_metadata_request())
 
-    def subscribe(self, stream):
+    def subscribe(self, stream, timeout=None):
         """
             Subscribe creates an ephemeral subscription for the given stream. It begins
             receiving messages starting at the configured position and waits for new
@@ -27,8 +26,11 @@ class Lift(BaseClient):
             does not exist.
         """
         logger.debug('Creating a new subscription to: %s' % stream)
-        for message in self._subscribe(self._subscribe_request(stream)):
-            yield message
+        try:
+            for message in self._subscribe(self._subscribe_request(stream), timeout):
+                yield message
+        except ErrDeadlineExceeded:
+            return
 
     def create_stream(self, stream):
         """
@@ -40,6 +42,14 @@ class Lift(BaseClient):
         logger.debug('Creating a new stream: %s' % stream)
         return self._create_stream(self._create_stream_request(stream))
 
+    def delete_stream(self, stream):
+        """
+            DeleteStream deletes a stream and all of its partitions. Name is the stream
+            identifier, globally unique.
+        """
+        logger.debug('Delete stream: %s' % stream)
+        return self._delete_stream(self._delete_stream_request(stream))
+
     def publish(self, message):
         """
             Publish publishes a new message to the Liftbridge stream.
@@ -48,7 +58,7 @@ class Lift(BaseClient):
         return self._publish(
             self._create_publish_request(message._build_message()),
         )
-    
+
     def publish_to_subject(self, message):
         """
             Publish publishes a new message to the NATS subject.
@@ -64,8 +74,19 @@ class Lift(BaseClient):
         return response
 
     @handle_rpc_errors_in_generator
-    def _subscribe(self, subscribe_request):
-        for message in self.stub.Subscribe(subscribe_request):
+    def _subscribe(self, subscribe_request, timeout=None):
+        # The first message in a subscription tells us if the subscribe succeeded.
+        # From the docs:
+        # """When the subscription stream is created, the server sends an
+        # empty message to indicate the subscription was successfully created.
+        # Otherwise, an error is sent on the stream if the subscribe failed.
+        # This handshake message must be handled and should not be exposed
+        # to the user."""
+        subscription = self.stub.Subscribe(subscribe_request, timeout)
+        first_message = next(subscription)
+        if first_message.value:
+            raise ErrChannelClosed(first_message.value)
+        for message in subscription:
             yield Message(
                 message.value,
                 message.subject,
@@ -80,10 +101,15 @@ class Lift(BaseClient):
         return response
 
     @handle_rpc_errors
+    def _delete_stream(self, stream_request):
+        response = self.stub.DeleteStream(stream_request)
+        return response
+
+    @handle_rpc_errors
     def _publish(self, publish_request):
         response = self.stub.Publish(publish_request)
         return response
-    
+
     @handle_rpc_errors
     def _publish_to_subject(self, publish_to_subject_request):
         response = self.stub.PublishToSubject(publish_to_subject_request)
@@ -98,6 +124,12 @@ class Lift(BaseClient):
             name=stream.name,
             group=stream.group,
             replicationFactor=stream.replication_factor,
+        )
+        return response
+
+    def _delete_stream_request(self, stream):
+        response = python_liftbridge.api_pb2.DeleteStreamRequest(
+            name=stream.name,
         )
         return response
 
@@ -122,7 +154,7 @@ class Lift(BaseClient):
 
     def _create_publish_request(self, message):
         return python_liftbridge.api_pb2.PublishRequest(
-            key=message.key, 
+            key=message.key,
             value=message.value,
             stream=message.stream,
             headers=message.headers,
@@ -131,10 +163,10 @@ class Lift(BaseClient):
             correlationId=message.correlationId,
             ackPolicy=message.ackPolicy,
         )
-    
+
     def _create_publish_to_subject_request(self, message):
         return python_liftbridge.api_pb2.PublishToSubjectRequest(
-            key=message.key, 
+            key=message.key,
             value=message.value,
             subject=message.subject,
             headers=message.headers,


### PR DESCRIPTION
* Add `delete_stream` to `python_liftbridge.Lift`
* Add `timeout` to `python_liftbridge.Lift.subscribe` to use gRPC Deadline for subscriptions
* Fix `python_liftbridge.Lift._subscribe` to match documented behaviour of server